### PR TITLE
test template functions using noproxy github assets

### DIFF
--- a/template-functions-noproxy/ship.yaml
+++ b/template-functions-noproxy/ship.yaml
@@ -1,0 +1,44 @@
+---
+assets:
+  v1:
+    - inline:
+        contents: |
+          #!/bin/bash
+          echo "installing nothing"
+          echo "semver: {{repl Installation "semver" }}"
+        dest: ./scripts/install.sh
+        mode: 0777
+    - github:
+        repo: replicatedhq/test-charts
+        path: template-functions/
+        dest: ./github-slash
+        source: public
+        ref: ad1e78d13c33fae7a7ce22ed19920945ceea23e9
+    - github:
+        repo: replicatedhq/test-charts
+        path: template-functions
+        dest: ./github-noslash
+        source: public
+        ref: ad1e78d13c33fae7a7ce22ed19920945ceea23e9
+    - github:
+        repo: replicatedhq/test-charts
+        path: template-functions
+        dest: ./github-stripped
+        strip_path: "{{repl ParseBool \"true\"}}"
+        source: public
+        ref: ad1e78d13c33fae7a7ce22ed19920945ceea23e9
+config:
+  v1:
+    - name: option_group
+      title: Test Option
+      description: testing testing 123
+      items:
+      - name: option
+        type: text
+        value: abc123
+
+lifecycle:
+  v1:
+    - config: {}
+    - render: {}
+


### PR DESCRIPTION
we test this within a ship app, but a ship yaml in an upstream is different

For use with replicatedhq/ship#833